### PR TITLE
Try to enhance recommendations with positive / negative votes instead of metacritic_score

### DIFF
--- a/scraper/upload-steam-games.ts
+++ b/scraper/upload-steam-games.ts
@@ -128,6 +128,14 @@ async function processGameData() {
             ...(item["tags"] ? Object.keys(item["tags"]) : []),
             ...(item["adultGame"] ? ["adult_game"] : []),
           ],
+          semantic_boost: {
+            distance_factor: 0.5,
+            phrase: item["name"]
+          },
+          fulltext_boost: {
+            boost_factor: 2,
+            phrase: item["name"]
+          },
           metadata: item,
           time_stamp: item["release_date"]
             ? new Date(item["release_date"]).toISOString()

--- a/scraper/upload-steam-games.ts
+++ b/scraper/upload-steam-games.ts
@@ -50,6 +50,8 @@ interface GameData {
   score_rank: string;
   positive: number;
   negative: number;
+  positiveNegativeRatio: number;
+  totalPositiveNegative: number;
   estimated_owners: string;
   average_playtime_forever: number;
   average_playtime_2weeks: number;
@@ -116,6 +118,11 @@ async function processGameData() {
         console.log("it");
         const item = JSON.parse(unserializedItem[0]);
         console.log("it", jobToSearchableString(item));
+
+        if ("positive" in item) {
+          item["positiveNegativeRatio"] = Math.ceil( (item["positive"] / (item["positive"] + (item["negative"] || 0)))*100 )
+          item["totalPositiveNegative"] = item["positive"] + (item["negative"] || 0)
+        }
 
         return {
           chunk_html: jobToSearchableString(item),

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.1",
     "@radix-ui/react-scroll-area": "^1.1.0",
+    "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-slider": "^1.2.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",

--- a/ui/src/components/GameCard.tsx
+++ b/ui/src/components/GameCard.tsx
@@ -19,50 +19,6 @@ const GameScore = ({
       "flex gap-4": !recommended,
     })}
   >
-    {game.metadata.metacritic_score ? (
-      <div className="flex gap-2 items-center">
-        <div className="flex items-center gap-2">
-          <IconStar
-            className={cn({
-              "w-3 h-3 fill-primary": true,
-              "fill-muted stroke-muted-foreground":
-                game.metadata.metacritic_score < 20,
-            })}
-          />
-          <IconStar
-            className={cn({
-              "w-3 h-3 fill-primary": true,
-              "fill-muted stroke-muted-foreground":
-                game.metadata.metacritic_score < 40,
-            })}
-          />
-          <IconStar
-            className={cn({
-              "w-3 h-3 fill-primary": true,
-              "fill-muted stroke-muted-foreground":
-                game.metadata.metacritic_score < 60,
-            })}
-          />
-          <IconStar
-            className={cn({
-              "w-3 h-3 fill-primary": true,
-              "fill-muted stroke-muted-foreground":
-                game.metadata.metacritic_score < 80,
-            })}
-          />
-          <IconStar
-            className={cn({
-              "w-3 h-3 fill-primary": true,
-              "fill-muted stroke-muted-foreground":
-                game.metadata.metacritic_score < 95,
-            })}
-          />
-          <span className="text-sm text-muted-foreground">
-            {game.metadata.metacritic_score}%
-          </span>
-        </div>
-      </div>
-    ) : null}
     {game.metadata.positive || game.metadata.negative ? (
       <div className="flex gap-2 items-center">
         <div className="flex items-center gap-4">

--- a/ui/src/components/GameModal.tsx
+++ b/ui/src/components/GameModal.tsx
@@ -1,6 +1,11 @@
 import { IconStar, IconThumbDown, IconThumbUp } from "@tabler/icons-react";
 import { DialogContent, DialogTitle } from "./ui/dialog";
 import { format } from "date-fns";
+import { GameCard } from "./GameCard";
+import { 
+  useState,
+  useEffect
+} from "react";
 import {
   Carousel,
   CarouselContent,
@@ -8,6 +13,9 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "./ui/carousel";
+import {
+  getRecommendations
+} from "@/lib/api"
 import { Chunk } from "@/lib/types";
 import { AsyncImage } from "loadable-image";
 import { ScrollArea } from "./ui/scroll-area";

--- a/ui/src/components/Recs.tsx
+++ b/ui/src/components/Recs.tsx
@@ -7,7 +7,9 @@ export const Recs = () => {
     recommendedGames,
     selectedGames,
     negativeGames,
+    recFromFilters,
   } = useGameState((state) => ({
+    recFromFilters: state.recFromFilters,
     getRecommendedGames: state.getRecommendedGames,
     selectedGames: state.selectedGames,
     recommendedGames: state.recommendedGames,
@@ -16,10 +18,10 @@ export const Recs = () => {
   }));
 
   useEffect(() => {
-    if (selectedGames.length > 0) {
-      getRecommendedGames();
+    if (selectedGames.length > 0 || negativeGames.length > 0) {
+      getRecommendedGames(recFromFilters);
     }
-  }, [selectedGames, negativeGames]);
+  }, [selectedGames, negativeGames, recFromFilters]);
 
   return (
     <div className="flex flex-col gap-4 sm:bg-slate-900 rounded-lg sm:p-3 max-h-[400px] overflow-auto sm:max-h-max order-1 sm:order-2">

--- a/ui/src/components/SearchAndFilters.tsx
+++ b/ui/src/components/SearchAndFilters.tsx
@@ -9,7 +9,7 @@ import { Combobox } from "./Combobox";
 
 export const SearchAndFilters = () => {
   const [query, setQuery] = useState("");
-  const [showFree, setShowFree] = useState(true);
+
   const [minScore, setMinScore] = useState(0);
   const [maxScore, setMaxScore] = useState(100);
   const debouncedSearchTerm = useDebounce(query, 300);
@@ -18,21 +18,24 @@ export const SearchAndFilters = () => {
     suggestedQueries,
     selectedCategory,
     setSelectedCategory,
+    recFromFilters,
+    setRecFromFilters
   } = useGameState((state) => ({
     getGamesForSearch: state.getGamesForSearch,
     suggestedQueries: state.suggestedQueries,
     selectedCategory: state.selectedCategory,
     setSelectedCategory: state.setSelectedCategory,
+    recFromFilters: state.recFromFilters,
+    setRecFromFilters: state.setRecFromFilters
   }));
 
   useEffect(() => {
     getGamesForSearch(debouncedSearchTerm, {
-      showFree,
       minScore,
       maxScore,
       selectedCategory,
     });
-  }, [debouncedSearchTerm, showFree, minScore, maxScore, selectedCategory]);
+  }, [debouncedSearchTerm, minScore, maxScore, selectedCategory]);
 
   return (
     <>
@@ -92,14 +95,14 @@ export const SearchAndFilters = () => {
         <div className="sm:flex inline-block items-center space-x-2 ">
           <Checkbox
             id="free"
-            checked={showFree}
-            onCheckedChange={(value) => setShowFree(value as boolean)}
+            checked={recFromFilters}
+            onCheckedChange={(value) => setRecFromFilters(value as boolean)}
           />
           <label
             htmlFor="free"
             className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
           >
-            Show free games
+            Reccomend From Generes
           </label>
         </div>
       </div>

--- a/ui/src/lib/gameState.ts
+++ b/ui/src/lib/gameState.ts
@@ -84,10 +84,14 @@ export const useGameState = create<GameState>()((set, get) => ({
         isLoading: false,
       }));
     } else {
-      const games = await getFirstLoadGames();
+      const [games, suggestedQueries] = await Promise.all([
+        getFirstLoadGames(),
+        getSuggestedQueries({ term: "Openworld fighting game" }),
+      ]);
+
       set(() => ({
         shownGames: games,
-        suggestedQueries: [],
+        suggestedQueries: suggestedQueries,
         isLoading: false,
       }));
     }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -610,6 +610,33 @@
     "@radix-ui/react-use-callback-ref" "1.1.0"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-select@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-2.1.1.tgz#df05cb0b29d3deaef83b505917c4042e0e418a9f"
+  integrity sha512-8iRDfyLtzxlprOo9IicnzvpsO1wNCkuwzzCM+Z5Rb5tNOpCdMvcc2AkzX0Fz+Tz9v6NJ5B/7EEgyZveo4FBRfQ==
+  dependencies:
+    "@radix-ui/number" "1.1.0"
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-collection" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-dismissable-layer" "1.1.0"
+    "@radix-ui/react-focus-guards" "1.1.0"
+    "@radix-ui/react-focus-scope" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-popper" "1.2.0"
+    "@radix-ui/react-portal" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-slot" "1.1.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+    "@radix-ui/react-use-previous" "1.1.0"
+    "@radix-ui/react-visually-hidden" "1.1.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.7"
+
 "@radix-ui/react-slider@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slider/-/react-slider-1.2.0.tgz#7a4c817d24386b420631a3fdc75563706d743472"


### PR DESCRIPTION
Things attempted so far.

- [x] Only doing a filter based on common tags (Sorta makes a difference)
- [x] Modifying recomendation type (Semantic seems best so far)
- [x] Fixed indexing to index everything
- [x] Added fulltext and semantic boosts.
- [ ] Sorting recs by popularity to make the result appear more relevant (may need a pr to server for this)

The weidest thing is the impact that negative results have. Sometimes they can make the results worse, but negative results + common tag filters does fix things. 
Common tag filter sometimes also doesn't make any changes. Want to get a much larger improvement for  a worth while blog post. Hoping that sorting or using other metadata fields will help to enhance this.

Things that are left:
- [ ] Showing how many positive / negative votes have been chosen
- [ ] Storing search state/filters in query parameters
- [ ] Storing positive / negative votes in local storage
- [ ] Showing recommendations in the Game Modal (Helps for a more finished polish)
- [ ] Stretch Goal: try to remove duplicate entries.
- [ ] Super stretch goal: Connect to steam account and recommend based off games you own. (Only if I have the energy for a "fun" extension)