### PR TITLE
fix suggested queries that have leading dashes

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -199,5 +199,7 @@ export const getSuggestedQueries = async ({ term }: { term: string }) => {
     options
   ).then((response) => response.json());
 
-  return data.queries.slice(0, 4);
+  return data.queries
+    .slice(0, 4)
+    .map((query: string) => query.replace(/^- /, ''));
 };


### PR DESCRIPTION
WIP
See #33 
This may perhaps resolved simply with a different LLM model instead. This is only a partial WIP fix, because sometimes the suggestions have numbering. Not in the issue, but sometimes they are also all in quotes (1x in dozens of attempts). I don't know if a single function is best for addressing all these issues, or perhaps this should be addressed via an issue at the server-level. 